### PR TITLE
Use Catch-All parameters when using config.CatchAll

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -135,7 +135,7 @@ func Serve() error {
 		}
 	} else {
 		log.Trace().Msg("Catch-All mode enabled...")
-    r.GET("/{path:*}", hellPot)
+		r.GET("/{path:*}", hellPot)
 	}
 
 	srv := getSrv(r)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -135,8 +135,7 @@ func Serve() error {
 		}
 	} else {
 		log.Trace().Msg("Catch-All mode enabled...")
-		r.GET("/", hellPot)
-		r.GET("/{path}", hellPot)
+    r.GET("/{path:*}", hellPot)
 	}
 
 	srv := getSrv(r)


### PR DESCRIPTION
The old implementation could fail to match for example `/.git/config`, but also nested paths such as `/example/here`.

See fasthttp/router docs for Catch-All [here](https://pkg.go.dev/github.com/fasthttp/router#readme-catch-all-parameters).

Solves #99 