### PR TITLE
Add logger.console_time_format option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,11 +133,12 @@ func loadCustomConfig(path string) {
 func processOpts() {
 	// string options and their exported variables
 	stringOpt := map[string]*string{
-		"http.bind_addr":        &HTTPBind,
-		"http.bind_port":        &HTTPPort,
-		"http.real_ip_header":   &HeaderName,
-		"logger.directory":      &logDir,
-		"deception.server_name": &FakeServerName,
+		"http.bind_addr":             &HTTPBind,
+		"http.bind_port":             &HTTPPort,
+		"http.real_ip_header":        &HeaderName,
+		"logger.directory":           &logDir,
+		"logger.console_time_format": &ConsoleTimeFormat,
+		"deception.server_name":      &FakeServerName,
 	}
 	// string slice options and their exported variables
 	strSliceOpt := map[string]*[]string{

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"time"
 
 	"github.com/spf13/afero"
 )
@@ -29,11 +30,12 @@ var (
 
 var defOpts = map[string]map[string]interface{}{
 	"logger": {
-		"debug":             true,
-		"trace":             false,
-		"nocolor":           defNoColor,
-		"use_date_filename": true,
-		"docker_logging":    false,
+		"debug":               true,
+		"trace":               false,
+		"nocolor":             defNoColor,
+		"use_date_filename":   true,
+		"docker_logging":      false,
+		"console_time_format": time.Kitchen,
 	},
 	"http": {
 		"use_unix_socket":         false,

--- a/internal/config/globals.go
+++ b/internal/config/globals.go
@@ -1,6 +1,8 @@
 package config
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+)
 
 // Title is the name of the application used throughout the configuration process.
 const Title = "HellPot"
@@ -39,6 +41,8 @@ var (
 	// CatchAll when true will cause HellPot to respond to all paths.
 	// Note that this will override MakeRobots.
 	CatchAll bool
+	// ConsoleTimeFormat sets the time format for the console. The string is passed to time.Format() down the line.
+	ConsoleTimeFormat string
 )
 
 // "http"

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -55,7 +55,7 @@ func StartLogger(pretty bool, targets ...io.Writer) zerolog.Logger {
 	var logWriter = logFile
 
 	if pretty {
-		logWriter = zerolog.MultiLevelWriter(zerolog.ConsoleWriter{NoColor: NoColor, Out: os.Stdout}, logFile)
+		logWriter = zerolog.MultiLevelWriter(zerolog.ConsoleWriter{TimeFormat: ConsoleTimeFormat, NoColor: NoColor, Out: os.Stdout}, logFile)
 	}
 
 	logger = zerolog.New(logWriter).With().Timestamp().Logger()


### PR DESCRIPTION
I personally enjoy watching the pretty logs from hell in my terminal, but I don't like AM/PM.

This allows users to set whatever they want in the console, while keeping the old `03:04PM` format as a default.

This change does not affect the logs written to file.

Right now I don't do any validation on the format, but setting the value to something like `666` just uses that for all the timestamps, which I guess is nice for screenshots.