### PR TITLE
Fix[#199]: bump go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as build
+FROM golang:1.23 as build
 WORKDIR /go/src/app
 
 COPY go.* .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/yunginnanet/HellPot
 
-go 1.21
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
### See: #199 